### PR TITLE
Fix test_glob

### DIFF
--- a/src/standard_libraries/test_glob.py
+++ b/src/standard_libraries/test_glob.py
@@ -11,7 +11,7 @@ import glob
 def test_glob():
     """File Wildcards."""
 
-    assert cmp(glob.glob('src/standard_libraries/glob_files/*.txt'), [
+    assert sorted(glob.glob('src/standard_libraries/glob_files/*.txt')) == sorted([
         'src/standard_libraries/glob_files/first_file.txt',
         'src/standard_libraries/glob_files/second_file.txt'
     ])

--- a/src/standard_libraries/test_glob.py
+++ b/src/standard_libraries/test_glob.py
@@ -11,7 +11,7 @@ import glob
 def test_glob():
     """File Wildcards."""
 
-    assert glob.glob('src/standard_libraries/glob_files/*.txt') == [
+    assert cmp(glob.glob('src/standard_libraries/glob_files/*.txt'), [
         'src/standard_libraries/glob_files/first_file.txt',
         'src/standard_libraries/glob_files/second_file.txt'
-    ]
+    ])


### PR DESCRIPTION
`==` operator for lists relies on the order of elements in the list.
In my case, on Linux Mint, python3.6 `glob()` returned list had items in reverse order then expected in the test.
The `glob()` doc doesn't specify items ordering.
Lets sort both lists before comparison using `sorted()` built-in.