### PR TITLE
Travis CI: Add flake8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 . --count --exit-zero --max-complexity=12 --max-line-length=127 --statistics
   - pylint ./src
   - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ python:
 # Install dependencies.
 install:
   - pip install -r requirements.txt
+  - pip install flake8
 
 # Run linting and tests.
 script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   - pylint ./src
   - pytest
 

--- a/src/control_flow/test_try.py
+++ b/src/control_flow/test_try.py
@@ -18,7 +18,7 @@ def test_try():
 
     # The try block will generate an error, because x is not defined:
     exception_has_been_caught = False
-    # pylint: disable=bare-except
+    # pylint: disable=bare-except,broad-except
     try:
         # pylint: disable=undefined-variable
         print(not_existing_variable)  # noqa: F821
@@ -31,7 +31,7 @@ def test_try():
     # block of code for a special kind of error:
     exception_message = ''
 
-    # pylint: disable=bare-except
+    # pylint: disable=broad-except
     try:
         # pylint: disable=undefined-variable
         print(not_existing_variable)
@@ -45,6 +45,7 @@ def test_try():
     # You can use the else keyword to define a block of code to be executed
     # if no errors were raised.
     message = ''
+    # pylint: disable=broad-except
     try:
         message += 'Success.'
     except Exception:
@@ -58,7 +59,7 @@ def test_try():
     # error or not.
     message = ''
     try:
-        # pylint: disable=undefined-variable
+        # pylint: disable=broad-except,undefined-variable
         print(not_existing_variable)  # noqa: F821
     except Exception:
         message += 'Something went wrong.'

--- a/src/control_flow/test_try.py
+++ b/src/control_flow/test_try.py
@@ -21,8 +21,8 @@ def test_try():
     # pylint: disable=bare-except
     try:
         # pylint: disable=undefined-variable
-        print(not_existing_variable)
-    except:
+        print(not_existing_variable)  # noqa: F821
+    except Exception:
         exception_has_been_caught = True
 
     assert exception_has_been_caught
@@ -37,7 +37,7 @@ def test_try():
         print(not_existing_variable)
     except NameError:
         exception_message = 'Variable is not defined'
-    except:
+    except Exception:
         exception_message = 'Something else went wrong'
 
     assert exception_message == 'Variable is not defined'
@@ -47,7 +47,7 @@ def test_try():
     message = ''
     try:
         message += 'Success.'
-    except:
+    except Exception:
         message += 'Something went wrong.'
     else:
         message += 'Nothing went wrong.'
@@ -59,8 +59,8 @@ def test_try():
     message = ''
     try:
         # pylint: disable=undefined-variable
-        print(not_existing_variable)
-    except:
+        print(not_existing_variable)  # noqa: F821
+    except Exception:
         message += 'Something went wrong.'
     finally:
         message += 'The "try except" is finished.'

--- a/src/data_types/test_lists.py
+++ b/src/data_types/test_lists.py
@@ -195,7 +195,7 @@ def test_del_statement():
     with pytest.raises(Exception):
         # Referencing the name a hereafter is an error (at least until another
         # value is assigned to it).
-        assert numbers == []
+        assert numbers == []  # noqa: F821
 
 
 def test_list_comprehensions():

--- a/src/modules/test_modules.py
+++ b/src/modules/test_modules.py
@@ -39,6 +39,7 @@ import fibonacci_module as fibonacci_module_renamed
 # It can also be used when utilising from with similar effects:
 from fibonacci_module import fibonacci_at_position as fibonacci_at_position_renamed
 
+
 # When a module named spam is imported, the interpreter first searches for a built-in module with
 # that name. If not found, it then searches for a file named spam.py in a list of directories
 # given by the variable sys.path. sys.path is initialized from these locations:


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

__learn-python__ should not teach the antipattern of bare exceptions.
* See PEP8 and https://realpython.com/the-most-diabolical-python-antipattern