### PR TITLE
Fix variable name: weapon -> fruit in list comprehension example (#105)

### DIFF
--- a/src/data_types/test_lists.py
+++ b/src/data_types/test_lists.py
@@ -263,7 +263,7 @@ def test_list_comprehensions():
 
     # Call a method on each element.
     fresh_fruit = ['  banana', '  loganberry ', 'passion fruit  ']
-    clean_fresh_fruit = [weapon.strip() for weapon in fresh_fruit]
+    clean_fresh_fruit = [fruit.strip() for fruit in fresh_fruit]
     assert clean_fresh_fruit == ['banana', 'loganberry', 'passion fruit']
 
     # Create a list of 2-tuples like (number, square).


### PR DESCRIPTION
## Description

Fix for issue #105.

In the list comprehension example that cleans whitespace from fruit names, the iteration variable was incorrectly named weapon instead of fruit. Since the list is called fresh_fruit and contains fruit names, using weapon is confusing for learners.

## Changes

- Line 266: Changed weapon.strip() to fruit.strip()
- Changed for weapon in to for fruit in

## Verification

The assertion still passes:
assert clean_fresh_fruit == [banana, loganberry, passion fruit]